### PR TITLE
Ensures quoting around PROJECT

### DIFF
--- a/templates/ios/Example/PROJECT.xcodeproj/project.pbxproj
+++ b/templates/ios/Example/PROJECT.xcodeproj/project.pbxproj
@@ -178,7 +178,7 @@
 			);
 			dependencies = (
 			);
-			name = PROJECT_Example;
+			name = "PROJECT_Example";
 			productName = "PROJECT";
 			productReference = 6003F58A195388D20070C39A /* PROJECT_Example.app */;
 			productType = "com.apple.product-type.application";
@@ -196,8 +196,8 @@
 			dependencies = (
 				6003F5B4195388D20070C39A /* PBXTargetDependency */,
 			);
-			name = PROJECT_Tests;
-			productName = PROJECTTests;
+			name = "PROJECT_Tests";
+			productName = "PROJECTTests";
 			productReference = 6003F5AE195388D20070C39A /* PROJECT_Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
@@ -209,7 +209,7 @@
 			attributes = {
 				CLASSPREFIX = CPD;
 				LastUpgradeCheck = 0720;
-				ORGANIZATIONNAME = PROJECT_OWNER;
+				ORGANIZATIONNAME = "PROJECT_OWNER";
 				TargetAttributes = {
 					6003F5AD195388D20070C39A = {
 						TestTargetID = 6003F589195388D20070C39A;

--- a/templates/swift/Example/PROJECT.xcodeproj/project.pbxproj
+++ b/templates/swift/Example/PROJECT.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 			);
 			dependencies = (
 			);
-			name = PROJECT_Example;
+			name = "PROJECT_Example";
 			productName = "PROJECT";
 			productReference = 607FACD01AFB9204008FA782 /* PROJECT_Example.app */;
 			productType = "com.apple.product-type.application";
@@ -154,7 +154,7 @@
 			dependencies = (
 				607FACE71AFB9204008FA782 /* PBXTargetDependency */,
 			);
-			name = PROJECT_Tests;
+			name = "PROJECT_Tests";
 			productName = Tests;
 			productReference = 607FACE51AFB9204008FA782 /* PROJECT_Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -351,7 +351,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = PROJECT/Info.plist;
+				INFOPLIST_FILE = "PROJECT/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -363,7 +363,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = PROJECT/Info.plist;
+				INFOPLIST_FILE = "PROJECT/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";


### PR DESCRIPTION
xcode, quite correctly, skips quotes if it doesn't have to. This kills the ability to script alas. 